### PR TITLE
Update /start script to allow for /exec execution

### DIFF
--- a/post-release
+++ b/post-release
@@ -17,23 +17,30 @@ for file in \$HOME/.profile.d/*; do source \$file; done
 hash -r
 cd \$HOME
 
-while read line || [ -n "\$line" ]; do
-  name=\${line%%:*}
-  command=\${line#*: }
-  echo "Starting \${name}..."
-  sh -c "\${command} | sed -e 's/^/\${name}| /'" &
-done < "Procfile"
-
-onexit() {
-  echo SIGINT received
-  echo sending SIGTERM to all processes
-  children=\$(ps --ppid=\$\$ -o pid='')
-  kill -- \$children &> /dev/null
-  sleep 1
-}
-trap onexit SIGTERM SIGINT EXIT
-
-wait
+case "\$(basename \$0)" in
+  start)
+    while read line || [ -n "\$line" ]; do
+      name=\${line%%:*}
+      command=\${line#*: }
+      echo "Starting \${name}..."
+      sh -c "\${command} | sed -e 's/^/\${name}| /'" &
+    done < "Procfile"
+    
+    onexit() {
+      echo SIGINT received
+      echo sending SIGTERM to all processes
+      children=\$(ps --ppid=\$\$ -o pid='')
+      kill -- \$children &> /dev/null
+      sleep 1
+    }
+    trap onexit SIGTERM SIGINT EXIT
+    
+    wait
+    ;;
+  *)
+    "\$@"
+    ;;
+esac
 EOF
 
 set -e


### PR DESCRIPTION
When the /start script was changed in progrium/buildstep@16e3f3c it started recognizing whether it was called as "start" or "anything else" to allow for being executed as "exec". This commit brings the dokku-shoreman version of the script up to speed with the buildstep one.

Resolves statianzo/dokku-shoreman#11