### PR TITLE
allowed realtime logging

### DIFF
--- a/post-build-buildstep
+++ b/post-build-buildstep
@@ -23,7 +23,7 @@ case "\$(basename \$0)" in
       name=\${line%%:*}
       command=\${line#*: }
       echo "Starting \${name}..."
-      sh -c "\${command} | sed -e 's/^/\${name}| /'" &
+      sh -c "\${command} | sed -u -e 's/^/\${name}| /'" &
     done < "Procfile"
     
     onexit() {


### PR DESCRIPTION
Fixes #14: Currently the logs are written delayed (caused by the prefixing via sed).

I changed sed command to use minimal buffering, so the logs are written in real time, as in standard dokku.