### PR TITLE
Drop down to the unprivileged user before running processes

### DIFF
--- a/post-build-buildstep
+++ b/post-build-buildstep
@@ -23,7 +23,7 @@ case "\$(basename \$0)" in
       name=\${line%%:*}
       command=\${line#*: }
       echo "Starting \${name}..."
-      sh -c "\${command} | sed -u -e 's/^/\${name}| /'" &
+      setuidgid "$(stat -c %U "$HOME")" sh -c "\${command} | sed -u -e 's/^/\${name}| /'" &
     done < "Procfile"
     
     onexit() {


### PR DESCRIPTION
Before executing the tasks in the Procfile, we should reduce our permissions so that they are run by the unprivileged user rather than as root.

This behaviour is in line with what happens when you aren't using dokku-shoreman, as demonstrated here: https://github.com/gliderlabs/herokuish/blob/f2f974ee2645bb418d35d5cd327b4f86b4f791f5/include/procfile.bash#L21

I've tested this on my own dokku instance, and running `whoami` from the Procfile confirms that privileges are dropped.