### PR TITLE
Plugin triggers have changed for V4,…

### DIFF
--- a/plugin.toml
+++ b/plugin.toml
@@ -1,0 +1,6 @@
+[plugin]
+name = "dokku-shoreman"
+description = "A plugin for dokku that injects a stripped down version of shoreman"
+version = "0.2.1"
+website_url = "https://github.com/pmvieira/dokku-shoreman"
+[plugin.config]

--- a/post-build-buildpack
+++ b/post-build-buildpack
@@ -1,0 +1,1 @@
+post-build-buildstep


### PR DESCRIPTION
 so post-build-builstep became post-build-buildpack.

Adding a  post-build-buildpack symlink to point to post-build-buildstep to ensure both Dokku V3 and V4 compatibility.